### PR TITLE
fix: isolate action from consumer package manager

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,14 +93,6 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: '22'
-        cache: 'npm'
-
-    - name: Cache dependencies
-      uses: actions/cache@v5
-      with:
-        path: ~/.npm
-        key: npm-${{ hashFiles('package-lock.json') }}
-        restore-keys: npm-
 
     - name: Download artifact
       if: contains(inputs.webapp-url, 'http://localhost')
@@ -115,8 +107,18 @@ runs:
       shell: bash
 
     - name: Set ACTION_PATH environment variable
-      run: echo "ACTION_PATH=${GITHUB_ACTION_PATH}" >> $GITHUB_ENV
+      id: set-action-path
+      run: |
+        echo "ACTION_PATH=${GITHUB_ACTION_PATH}" >> $GITHUB_ENV
+        echo "lockfile-hash=$(sha256sum ${GITHUB_ACTION_PATH}/package-lock.json | cut -c1-16)" >> $GITHUB_OUTPUT
       shell: bash
+
+    - name: Cache action dependencies
+      uses: actions/cache@v5
+      with:
+        path: ${{ env.ACTION_PATH }}/node_modules
+        key: action-deps-${{ steps.set-action-path.outputs.lockfile-hash }}
+        restore-keys: action-deps-
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
## Summary

- Remove `cache: 'npm'` from `setup-node` — the consumer's package manager is irrelevant to the action
- Remove the `Cache dependencies` step that targeted `~/.npm` keyed off the consumer's `package-lock.json` — broken for pnpm/yarn consumers and meaningless anyway
- Add an action-scoped cache for `ACTION_PATH/node_modules` keyed off the action's own `package-lock.json` hash — proper isolation

The action only needs the consumer checkout to read a pre-script file. Everything else (Node.js, dependencies, Playwright) is self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)