### PR TITLE
feat: distinguish filtered logs from no logs in empty-output message

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -163,10 +163,19 @@ runs:
         echo "# ${{ inputs.headline }}" > formatted_console_output.md
         # Check if the console_output.json file is empty or contains no logs
         if [ ! -s console_output.json ] || [ "$(jq -r 'keys | length' console_output.json)" -eq 0 ]; then
+          total_observed=$(jq -r '.totalObserved' capture_stats.json 2>/dev/null || echo "0")
           if [ "${{ inputs.show-emoji }}" = "true" ]; then
-            echo "✅ No logs were captured" >> formatted_console_output.md
+            if [ "$total_observed" -gt 0 ]; then
+              echo "✅ No unexpected logs were captured" >> formatted_console_output.md
+            else
+              echo "✅ No logs were captured" >> formatted_console_output.md
+            fi
           else
+            if [ "$total_observed" -gt 0 ]; then
+              echo "No unexpected logs were captured" >> formatted_console_output.md
+            else
               echo "No logs were captured" >> formatted_console_output.md
+            fi
           fi
         else
           # Loop through each key in the JSON file

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ const captureUrl = port ? `${webAppUrl}:${port}` : webAppUrl;
  */
 let shouldFailAction = false;
 let shouldCaptureMessages = !process.env.PRE_SCRIPT_PATH;
+let totalMessagesObserved = 0;
 
 /**
  Mapping of console message types to log levels.
@@ -89,6 +90,8 @@ page.on('console', message => {
 	if (!shouldCaptureMessages) {
 		return;
 	}
+
+	totalMessagesObserved++;
 
 	const messageType = message.type();
 	const logLevel = logLevelMapping[messageType] || 'info';
@@ -136,6 +139,7 @@ for (const [key, value] of consoleMessages) {
 }
 
 await fs.writeFile('console_output.json', JSON.stringify(Object.fromEntries(consoleMessages), null, 2));
+await fs.writeFile('capture_stats.json', JSON.stringify({totalObserved: totalMessagesObserved}, null, 2));
 
 await browser.close();
 

--- a/index.test.js
+++ b/index.test.js
@@ -9,7 +9,7 @@ import {
 	vi,
 } from 'vitest';
 import {chromium} from 'playwright';
-import {shouldFail} from './utils.js';
+import {shouldFail, filterMessage} from './utils.js';
 import {runPreScript} from './pre-script.js';
 
 let consoleListener;
@@ -90,6 +90,7 @@ describe('index.js', () => {
 		expect(page.goto).toHaveBeenCalled();
 		expect(page.waitForTimeout).toHaveBeenCalled();
 		expect(fs.writeFile).toHaveBeenCalledWith('console_output.json', JSON.stringify({info: ['Test message']}, null, 2));
+		expect(fs.writeFile).toHaveBeenCalledWith('capture_stats.json', JSON.stringify({totalObserved: 1}, null, 2));
 	});
 
 	test('should handle different log levels', async () => {
@@ -171,5 +172,17 @@ describe('index.js', () => {
 		await import('./index.js');
 
 		expect(fs.writeFile).toHaveBeenCalledWith('console_output.json', JSON.stringify({info: ['Captured during pre-script']}, null, 2));
+	});
+
+	test('should write totalObserved > 0 even when all messages are filtered out', async () => {
+		vi.mocked(filterMessage).mockReturnValue(''); // Everything filtered out
+		page.goto.mockImplementation(async () => {
+			consoleListener({type: () => 'log', text: () => 'This gets filtered'});
+		});
+
+		await import('./index.js');
+
+		expect(fs.writeFile).toHaveBeenCalledWith('capture_stats.json', JSON.stringify({totalObserved: 1}, null, 2));
+		expect(fs.writeFile).toHaveBeenCalledWith('console_output.json', JSON.stringify({}, null, 2));
 	});
 });


### PR DESCRIPTION
## Summary

- Adds a `totalObserved` counter in `index.js` that tracks how many console messages were seen during the capture window (after pre-script, before any level/regexp filtering)
- Writes `capture_stats.json` alongside `console_output.json` with `{ "totalObserved": N }`
- The "Format Console Output" step in `action.yml` now shows:
  - ✅ **No logs were captured** — nothing was logged at all
  - ✅ **No unexpected logs were captured** — logs were seen but all filtered out (by log level or regexp)

## Why

Previously both states showed the same message, which was misleading when filters were active. The new distinction gives a clearer signal without exposing *why* things were filtered (level vs regexp — that would over-complicate the output).