### PR TITLE
ci: reusable-workflow CI with per-scenario artifact names and an all-green gate

### DIFF
--- a/.github/workflows/_fail_all-defaults.yml
+++ b/.github/workflows/_fail_all-defaults.yml
@@ -1,12 +1,7 @@
 name: "Negative Test - all defaults"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -48,14 +43,14 @@ jobs:
       - name: Upload index.html
         uses: actions/upload-artifact@v7
         with:
-          name: index-html
+          name: index-html-fail-all-defaults
           path: index.html
 
       - name: Use WebApp Console Log Action
         id: webapp_console_log
         uses: ./
         with:
-          artifact-name: index-html
+          artifact-name: index-html-fail-all-defaults
           webapp-url: 'http://localhost'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_fail_http-status-404.yml
+++ b/.github/workflows/_fail_http-status-404.yml
@@ -1,12 +1,7 @@
-name: "Negative Test - missing artifact name"
+name: "Negative Test - HTTP 404 fails by default"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,16 +9,30 @@ permissions:
 jobs:
   fail:
     runs-on: ubuntu-latest
-    name: Should fail early - has localhost but no artifact name
+    name: Should fail - HTTP 404 fails by default (validate-status enabled)
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+
+      - name: Create app with placeholder file
+        run: |
+          mkdir -p app
+          touch app/index.html
+
+      - name: Upload app
+        uses: actions/upload-artifact@v7
+        with:
+          name: empty-app-404
+          path: app
 
       - name: Use WebApp Console Log Action
         id: webapp_console_log
         uses: ./
         with:
-          webapp-url: 'http://localhost'
+          artifact-name: empty-app-404
+          comment-tag: fail-http-status-404
+          headline: Should fail - HTTP 404 fails by default
+          webapp-url: 'http://localhost/nonexistent-page.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true

--- a/.github/workflows/_fail_missing-artifact-name.yml
+++ b/.github/workflows/_fail_missing-artifact-name.yml
@@ -1,12 +1,7 @@
-name: "Negative Test - HTTP 404 fails by default"
+name: "Negative Test - missing artifact name"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,30 +9,16 @@ permissions:
 jobs:
   fail:
     runs-on: ubuntu-latest
-    name: Should fail - HTTP 404 fails by default (validate-status enabled)
+    name: Should fail early - has localhost but no artifact name
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-
-      - name: Create app with placeholder file
-        run: |
-          mkdir -p app
-          touch app/index.html
-
-      - name: Upload app
-        uses: actions/upload-artifact@v7
-        with:
-          name: empty-app-404
-          path: app
 
       - name: Use WebApp Console Log Action
         id: webapp_console_log
         uses: ./
         with:
-          artifact-name: empty-app-404
-          comment-tag: fail-http-status-404
-          headline: Should fail - HTTP 404 fails by default
-          webapp-url: 'http://localhost/nonexistent-page.html'
+          webapp-url: 'http://localhost'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true

--- a/.github/workflows/_lint-pr-title.yml
+++ b/.github/workflows/_lint-pr-title.yml
@@ -1,12 +1,7 @@
 name: "Lint PR Title"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - reopened
+  workflow_call:
 
 jobs:
   sync-pr-title-with-commits:

--- a/.github/workflows/_pass_all-inputs.yml
+++ b/.github/workflows/_pass_all-inputs.yml
@@ -1,12 +1,7 @@
-name: "Positive Test - regular expression"
+name: "Positive Test - all parameters set"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,7 +9,7 @@ permissions:
 jobs:
   pass:
     runs-on: ubuntu-latest
-    name: Should pass - has regular expression
+    name: Should pass - has all parameters set
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -48,20 +43,21 @@ jobs:
       - name: Upload index.html
         uses: actions/upload-artifact@v7
         with:
-          name: index-html
+          name: index-html-pass-all-inputs
           path: index.html
 
       - name: Use WebApp Console Log Action
         uses: ./
         with:
-          artifact-name: index-html
-          comment-tag: pass-regexp
-          headline: Some messages will be hidden by the regexp
+          artifact-name: index-html-pass-all-inputs
+          comment-tag: pass-all-inputs
+          headline: No emojis, min log level warning, max log level error
           max-log-level: error
+          min-log-level: warning
+          port: 3001
           regexp-error: 'This is' # This is an error in => an error in (trimmed)
-          regexp-info: 'This \D+ workflow' # info and log completely hidden
-          regexp-verbose: 'debug ' # This is a debug message => This is a message
           regexp-warning: 'pass ' # in the pass workflow => in the workflow
+          show-emoji: false
           wait-time: 5
           webapp-url: 'http://localhost'
         env:

--- a/.github/workflows/_pass_external-login-pre-script.yml
+++ b/.github/workflows/_pass_external-login-pre-script.yml
@@ -1,12 +1,7 @@
 name: "Positive Test - external login pre-script"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/_pass_http-status-no-validate.yml
+++ b/.github/workflows/_pass_http-status-no-validate.yml
@@ -1,12 +1,7 @@
-name: "Positive Test - HTTP 404 passes when configured as positive"
+name: "Positive Test - HTTP 404 passes when validation disabled"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,7 +9,7 @@ permissions:
 jobs:
   pass:
     runs-on: ubuntu-latest
-    name: Should pass - HTTP 404 is an expected positive status code
+    name: Should pass - HTTP 404 passes when validate-status is false
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -27,17 +22,17 @@ jobs:
       - name: Upload app
         uses: actions/upload-artifact@v7
         with:
-          name: empty-app-positive-404
+          name: empty-app-no-validate
           path: app
 
       - name: Use WebApp Console Log Action
         uses: ./
         with:
-          artifact-name: empty-app-positive-404
-          comment-tag: pass-http-status-positive-404
-          headline: Should pass - HTTP 404 is a configured positive status
+          artifact-name: empty-app-no-validate
+          comment-tag: pass-http-status-no-validate
+          headline: Should pass - HTTP 404 ignored when validate-status is false
           max-log-level: 'error'
-          positive-statuses: '200,404'
+          validate-status: 'false'
           webapp-url: 'http://localhost/nonexistent-page.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_pass_http-status-positive-404.yml
+++ b/.github/workflows/_pass_http-status-positive-404.yml
@@ -1,12 +1,7 @@
-name: "Positive Test - HTTP 404 passes when validation disabled"
+name: "Positive Test - HTTP 404 passes when configured as positive"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,7 +9,7 @@ permissions:
 jobs:
   pass:
     runs-on: ubuntu-latest
-    name: Should pass - HTTP 404 passes when validate-status is false
+    name: Should pass - HTTP 404 is an expected positive status code
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -27,17 +22,17 @@ jobs:
       - name: Upload app
         uses: actions/upload-artifact@v7
         with:
-          name: empty-app-no-validate
+          name: empty-app-positive-404
           path: app
 
       - name: Use WebApp Console Log Action
         uses: ./
         with:
-          artifact-name: empty-app-no-validate
-          comment-tag: pass-http-status-no-validate
-          headline: Should pass - HTTP 404 ignored when validate-status is false
+          artifact-name: empty-app-positive-404
+          comment-tag: pass-http-status-positive-404
+          headline: Should pass - HTTP 404 is a configured positive status
           max-log-level: 'error'
-          validate-status: 'false'
+          positive-statuses: '200,404'
           webapp-url: 'http://localhost/nonexistent-page.html'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_pass_localhost-no-port.yml
+++ b/.github/workflows/_pass_localhost-no-port.yml
@@ -1,12 +1,7 @@
-name: "Positive Test - all parameters set"
+name: "Positive Test - has localhost but no port"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,7 +9,7 @@ permissions:
 jobs:
   pass:
     runs-on: ubuntu-latest
-    name: Should pass - has all parameters set
+    name: Should pass - has localhost but no port
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -48,21 +43,17 @@ jobs:
       - name: Upload index.html
         uses: actions/upload-artifact@v7
         with:
-          name: index-html
+          name: index-html-pass-localhost-no-port
           path: index.html
 
       - name: Use WebApp Console Log Action
         uses: ./
         with:
-          artifact-name: index-html
-          comment-tag: pass-all-inputs
-          headline: No emojis, min log level warning, max log level error
+          artifact-name: index-html-pass-localhost-no-port
+          comment-tag: pass-localhost-no-port
+          headline: Should pass - has localhost but no port
           max-log-level: error
           min-log-level: warning
-          port: 3001
-          regexp-error: 'This is' # This is an error in => an error in (trimmed)
-          regexp-warning: 'pass ' # in the pass workflow => in the workflow
-          show-emoji: false
           wait-time: 5
           webapp-url: 'http://localhost'
         env:

--- a/.github/workflows/_pass_logs-below-threshold.yml
+++ b/.github/workflows/_pass_logs-below-threshold.yml
@@ -1,12 +1,7 @@
-name: "Positive Test - page emits no logs at all"
+name: "Positive Test - logs below min-log-level"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,12 +9,12 @@ permissions:
 jobs:
   pass:
     runs-on: ubuntu-latest
-    name: Should pass - page emits no logs at all (totalObserved = 0)
+    name: Should pass - page has logs but all below min-log-level threshold
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Create fake App with no console outputs
+      - name: Create fake App with console outputs below threshold
         run: |
           touch index.html
           
@@ -29,10 +24,12 @@ jobs:
           <html>
           <head>
           <title>New Page</title>
-          <link rel="icon" href="data:,">
           </head>
           <body>
               <h1>Hello, World!</h1>
+              <script>
+                console.debug('This is a debug message and likely hidden in the pass workflow');
+              </script>
           </body>
           </html>
           
@@ -41,15 +38,16 @@ jobs:
       - name: Upload index.html
         uses: actions/upload-artifact@v7
         with:
-          name: index-html-no-console
+          name: index-html-pass-logs-below-threshold
           path: index.html
 
       - name: Use WebApp Console Log Action
         uses: ./
         with:
-          artifact-name: index-html-no-console
-          comment-tag: pass-page-emits-no-logs
-          headline: Should pass - page emits no logs at all
+          artifact-name: index-html-pass-logs-below-threshold
+          comment-tag: pass-logs-below-threshold
+          headline: Should pass - all logs below min-log-level threshold
+          min-log-level: warning
           wait-time: 5
           webapp-url: 'http://localhost'
         env:

--- a/.github/workflows/_pass_page-emits-no-logs.yml
+++ b/.github/workflows/_pass_page-emits-no-logs.yml
@@ -1,12 +1,7 @@
-name: "Positive Test - logs below min-log-level"
+name: "Positive Test - page emits no logs at all"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,12 +9,12 @@ permissions:
 jobs:
   pass:
     runs-on: ubuntu-latest
-    name: Should pass - page has logs but all below min-log-level threshold
+    name: Should pass - page emits no logs at all (totalObserved = 0)
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Create fake App with console outputs below threshold
+      - name: Create fake App with no console outputs
         run: |
           touch index.html
           
@@ -29,12 +24,10 @@ jobs:
           <html>
           <head>
           <title>New Page</title>
+          <link rel="icon" href="data:,">
           </head>
           <body>
               <h1>Hello, World!</h1>
-              <script>
-                console.debug('This is a debug message and likely hidden in the pass workflow');
-              </script>
           </body>
           </html>
           
@@ -43,16 +36,15 @@ jobs:
       - name: Upload index.html
         uses: actions/upload-artifact@v7
         with:
-          name: index-html
+          name: index-html-no-console
           path: index.html
 
       - name: Use WebApp Console Log Action
         uses: ./
         with:
-          artifact-name: index-html
-          comment-tag: pass-logs-below-threshold
-          headline: Should pass - all logs below min-log-level threshold
-          min-log-level: warning
+          artifact-name: index-html-no-console
+          comment-tag: pass-page-emits-no-logs
+          headline: Should pass - page emits no logs at all
           wait-time: 5
           webapp-url: 'http://localhost'
         env:

--- a/.github/workflows/_pass_regexp.yml
+++ b/.github/workflows/_pass_regexp.yml
@@ -1,12 +1,7 @@
-name: "Positive Test - has localhost but no port"
+name: "Positive Test - regular expression"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write
@@ -14,7 +9,7 @@ permissions:
 jobs:
   pass:
     runs-on: ubuntu-latest
-    name: Should pass - has localhost but no port
+    name: Should pass - has regular expression
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -48,17 +43,20 @@ jobs:
       - name: Upload index.html
         uses: actions/upload-artifact@v7
         with:
-          name: index-html
+          name: index-html-pass-regexp
           path: index.html
 
       - name: Use WebApp Console Log Action
         uses: ./
         with:
-          artifact-name: index-html
-          comment-tag: pass-localhost-no-port
-          headline: Should pass - has localhost but no port
+          artifact-name: index-html-pass-regexp
+          comment-tag: pass-regexp
+          headline: Some messages will be hidden by the regexp
           max-log-level: error
-          min-log-level: warning
+          regexp-error: 'This is' # This is an error in => an error in (trimmed)
+          regexp-info: 'This \D+ workflow' # info and log completely hidden
+          regexp-verbose: 'debug ' # This is a debug message => This is a message
+          regexp-warning: 'pass ' # in the pass workflow => in the workflow
           wait-time: 5
           webapp-url: 'http://localhost'
         env:

--- a/.github/workflows/_pass_uses-external-url.yml
+++ b/.github/workflows/_pass_uses-external-url.yml
@@ -1,12 +1,7 @@
 name: "Positive Test - uses external URL"
 
 on:
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - closed
+  workflow_call:
 
 permissions:
   pull-requests: write

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,10 +1,7 @@
 name: "Test"
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,147 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+      - edited
+
+permissions: {}
+
+jobs:
+  test:
+    if: github.event_name == 'push' || (github.base_ref == 'main' && contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_test.yml
+    secrets: inherit
+
+  lint-pr-title:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","edited","synchronize","reopened"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_lint-pr-title.yml
+    secrets: inherit
+
+  fail-all-defaults:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_fail_all-defaults.yml
+    secrets: inherit
+
+  fail-http-status-404:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_fail_http-status-404.yml
+    secrets: inherit
+
+  fail-missing-artifact-name:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_fail_missing-artifact-name.yml
+    secrets: inherit
+
+  pass-all-inputs:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_all-inputs.yml
+    secrets: inherit
+
+  pass-external-login-pre-script:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_external-login-pre-script.yml
+    secrets: inherit
+
+  pass-http-status-no-validate:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_http-status-no-validate.yml
+    secrets: inherit
+
+  pass-http-status-positive-404:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_http-status-positive-404.yml
+    secrets: inherit
+
+  pass-localhost-no-port:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_localhost-no-port.yml
+    secrets: inherit
+
+  pass-logs-below-threshold:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_logs-below-threshold.yml
+    secrets: inherit
+
+  pass-page-emits-no-logs:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_page-emits-no-logs.yml
+    secrets: inherit
+
+  pass-regexp:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_regexp.yml
+    secrets: inherit
+
+  pass-uses-external-url:
+    if: github.event_name == 'pull_request' && contains(fromJSON('["opened","reopened","synchronize","closed"]'), github.event.action)
+    permissions:
+      pull-requests: write
+    uses: ./.github/workflows/_pass_uses-external-url.yml
+    secrets: inherit
+
+  all-green:
+    name: All checks green
+    if: always()
+    needs:
+      - test
+      - lint-pr-title
+      - fail-all-defaults
+      - fail-http-status-404
+      - fail-missing-artifact-name
+      - pass-all-inputs
+      - pass-external-login-pre-script
+      - pass-http-status-no-validate
+      - pass-http-status-positive-404
+      - pass-localhost-no-port
+      - pass-logs-below-threshold
+      - pass-page-emits-no-logs
+      - pass-regexp
+      - pass-uses-external-url
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        shell: bash
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Job results: $results"
+          for r in $results; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::A required job did not pass (result=$r)."
+              exit 1
+            fi
+          done
+          echo "All jobs succeeded or were skipped."


### PR DESCRIPTION
## What

Consolidates the repository's per-scenario CI workflows into a single orchestrator (`ci.yml`) that fans out to reusable `_*.yml` workflows and gates everything behind one required **All checks green** job. This supersedes the monolithic attempt in #81.

## Why the previous attempt (#81) was red

Every `pass_*`/`fail_*` scenario that built a local page uploaded and read an artifact named `index-html`. Folding them into one workflow run made those uploads collide (duplicate artifact name in a single run). This PR keeps the reusable-workflow isolation and additionally makes each colliding artifact name unique per scenario.

## Structure (mirrors the merged Gyros reusable layout)

- Each former workflow → a reusable `_<name>.yml` with `on: workflow_call` and its job(s) verbatim (only artifact names changed where needed).
- `ci.yml` orchestrator: `on: push:[main] + pull_request` (union of the originals' PR types), `permissions: {}`, one caller job per reusable (`uses:` + `secrets: inherit` + a trigger guard preserving each original's `on:` intent), plus an inline `all-green` job (`name: All checks green`, `if: always()`, `needs:` all callers) running the verbatim aggregator.

## Artifact-name fix (per-scenario unique names)

| Scenario | old | new |
|---|---|---|
| fail_all-defaults | `index-html` | `index-html-fail-all-defaults` |
| pass_all-inputs | `index-html` | `index-html-pass-all-inputs` |
| pass_localhost-no-port | `index-html` | `index-html-pass-localhost-no-port` |
| pass_logs-below-threshold | `index-html` | `index-html-pass-logs-below-threshold` |
| pass_regexp | `index-html` | `index-html-pass-regexp` |

Scenarios that already used unique names are untouched (`empty-app-404`, `empty-app-no-validate`, `empty-app-positive-404`, `index-html-no-console`); scenarios with no artifact wiring are unchanged. In every renamed scenario the `upload-artifact` `name:` and the action's `artifact-name:` input still match each other.

## Notes

- `release-please.yml` is intentionally kept separate.
- Do NOT merge — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)